### PR TITLE
Adding necessary Cpp header to compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+set(CPP_STATEMACHINE_LIBRARY_NAME Cpp_StateMachine)
+
+set(C_STATEMACHINE_CSRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/Allocator.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Fault.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/StateMachine.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/xallocator.cpp)
+
+add_library(${CPP_STATEMACHINE_LIBRARY_NAME} ${C_STATEMACHINE_CSRC})
+
+target_compile_definitions(
+  ${CPP_STATEMACHINE_LIBRARY_NAME}
+  PRIVATE STATIC_POOLS
+          EXTERNAL_EVENT_NO_HEAP_DATA=1)
+target_compile_options(
+  ${CPP_STATEMACHINE_LIBRARY_NAME}
+  PRIVATE -Wno-unused-parameter
+          -Wno-unused-variable
+  PUBLIC -Wno-unused-but-set-variable)
+target_include_directories(${CPP_STATEMACHINE_LIBRARY_NAME}
+                           PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/StateMachine.cpp
+++ b/StateMachine.cpp
@@ -12,7 +12,7 @@ StateMachine::StateMachine(BYTE maxStates, BYTE initialState) :
 	m_pEventData(NULL)
 {
 	ASSERT_TRUE(MAX_STATES < EVENT_IGNORED);
-}  
+}
 
 //----------------------------------------------------------------------------
 // ExternalEvent
@@ -44,7 +44,7 @@ void StateMachine::ExternalEvent(BYTE newState, const EventData* pData)
 		// when all state machine events are processed.
 		StateEngine();
 
-		// TODO - release software lock here 
+		// TODO - release software lock here
 	}
 }
 
@@ -53,12 +53,19 @@ void StateMachine::ExternalEvent(BYTE newState, const EventData* pData)
 //----------------------------------------------------------------------------
 void StateMachine::InternalEvent(BYTE newState, const EventData* pData)
 {
-	if (pData == NULL)
+	// if (pData == NULL)
+	// 	pData = new NoEventData();
+#ifndef EXTERNAL_EVENT_NO_HEAP_DATA
+  if (pData == NULL) {
 		pData = new NoEventData();
+	}
+#else
+  assert(pData != NULL);
+#endif  // EXTERNAL_EVENT_NO_HEAP_DATA
 
-	m_pEventData = pData;
-	m_eventGenerated = TRUE;
-	m_newState = newState;
+  m_pEventData = pData;
+  m_eventGenerated = TRUE;
+  m_newState = newState;
 }
 
 //----------------------------------------------------------------------------
@@ -87,7 +94,7 @@ void StateMachine::StateEngine(const StateMapRow* const pStateMap)
 #if EXTERNAL_EVENT_NO_HEAP_DATA
 	BOOL externalEvent = TRUE;
 #endif
-	const EventData* pDataTemp = NULL;	
+	const EventData* pDataTemp = NULL;
 
 	// While events are being generated keep executing states
 	while (m_eventGenerated)
@@ -183,7 +190,7 @@ void StateMachine::StateEngine(const StateMapRowEx* const pStateMapEx)
 				if (entry != NULL)
 					entry->InvokeEntryAction(this, pDataTemp);
 
-				// Ensure exit/entry actions didn't call InternalEvent by accident 
+				// Ensure exit/entry actions didn't call InternalEvent by accident
 				ASSERT_TRUE(m_eventGenerated == FALSE);
 			}
 

--- a/StateMachine.h
+++ b/StateMachine.h
@@ -7,18 +7,18 @@
 #include "Fault.h"
 
 // If EXTERNAL_EVENT_NO_HEAP_DATA is defined it changes how a client sends data to the
-// state machine. When undefined, the ExternalEvent() pData argument must be created on the heap. 
-// The state machine will automatically delete the EventData pointer during state execution. 
-// When defined, clients must not heap allocate EventData with operator new. InternalEvent() 
-// used inside the state machine always heap allocates event data. 
+// state machine. When undefined, the ExternalEvent() pData argument must be created on the heap.
+// The state machine will automatically delete the EventData pointer during state execution.
+// When defined, clients must not heap allocate EventData with operator new. InternalEvent()
+// used inside the state machine always heap allocates event data.
 //#define EXTERNAL_EVENT_NO_HEAP_DATA 1
 
 // See http://www.codeproject.com/Articles/1087619/State-Machine-Design-in-Cplusplus
 
-// Uncomment the include below the XALLOCATOR line to use the xallocator instead 
-// of the global heap. Any EventData, or derived class thereof, created with 
-// new/delete will be routed to the xallocator. See xallocator.h for more info. 
-//#include "xallocator.h"
+// Uncomment the include below the XALLOCATOR line to use the xallocator instead
+// of the global heap. Any EventData, or derived class thereof, created with
+// new/delete will be routed to the xallocator. See xallocator.h for more info.
+// #include "xallocator.h"
 
 /// @beief Unique state machine event data must inherit from this class.
 class EventData
@@ -37,27 +37,27 @@ class StateBase
 {
 public:
 	/// Called by the state machine engine to execute a state action. If a guard condition
-	/// exists and it evaluates to false, the state action will not execute. 
-	/// @param[in] sm - A state machine instance. 
-	/// @param[in] data - The event data. 
+	/// exists and it evaluates to false, the state action will not execute.
+	/// @param[in] sm - A state machine instance.
+	/// @param[in] data - The event data.
 	virtual void InvokeStateAction(StateMachine* sm, const EventData* data) const = 0;
 };
 
 /// @brief StateAction takes three template arguments: A state machine class,
-/// a state function event data type (derived from EventData) and a state machine 
-/// member function pointer.  
+/// a state function event data type (derived from EventData) and a state machine
+/// member function pointer.
 template <class SM, class Data, void (SM::*Func)(const Data*)>
 class StateAction : public StateBase
 {
 public:
 	/// @see StateBase::InvokeStateAction
-	virtual void InvokeStateAction(StateMachine* sm, const EventData* data) const 
+	virtual void InvokeStateAction(StateMachine* sm, const EventData* data) const
 	{
 		// Downcast the state machine and event data to the correct derived type
 		SM* derivedSM = static_cast<SM*>(sm);
-		
-		// If this check fails, there is a mismatch between the STATE_DECLARE 
-		// event data type and the data type being sent to the state function. 
+
+		// If this check fails, there is a mismatch between the STATE_DECLARE
+		// event data type and the data type being sent to the state function.
 		// For instance, given the following state defintion:
 		//    STATE_DECLARE(MyStateMachine, MyStateFunction, MyEventData)
 		// The following internal event transition is valid:
@@ -79,22 +79,22 @@ public:
 	/// Called by the state machine engine to execute a guard condition action. If guard
 	/// condition evaluates to TRUE the state action is executed. If FALSE, no state transition
 	/// is performed.
-	/// @param[in] sm - A state machine instance. 
-	/// @param[in] data - The event data. 
+	/// @param[in] sm - A state machine instance.
+	/// @param[in] data - The event data.
 	/// @return Returns TRUE if no guard condition or the guard condition evaluates to TRUE.
 	virtual BOOL InvokeGuardCondition(StateMachine* sm, const EventData* data) const = 0;
 };
 
 /// @brief GuardCondition takes three template arguments: A state machine class,
-/// a state function event data type (derived from EventData) and a state machine 
-/// member function pointer. 
+/// a state function event data type (derived from EventData) and a state machine
+/// member function pointer.
 template <class SM, class Data, BOOL (SM::*Func)(const Data*)>
 class GuardCondition : public GuardBase
 {
 public:
-	virtual BOOL InvokeGuardCondition(StateMachine* sm, const EventData* data) const 
+	virtual BOOL InvokeGuardCondition(StateMachine* sm, const EventData* data) const
 	{
-		SM* derivedSM = static_cast<SM*>(sm);		
+		SM* derivedSM = static_cast<SM*>(sm);
 		const Data* derivedData = dynamic_cast<const Data*>(data);
 		ASSERT_TRUE(derivedData != NULL);
 
@@ -108,15 +108,15 @@ class EntryBase
 {
 public:
 	/// Called by the state machine engine to execute a state entry action. Called when
-	/// entering a state. 
-	/// @param[in] sm - A state machine instance. 
+	/// entering a state.
+	/// @param[in] sm - A state machine instance.
 	/// @param[in] data - The event data.
 	virtual void InvokeEntryAction(StateMachine* sm, const EventData* data) const = 0;
 };
 
 /// @brief EntryAction takes three template arguments: A state machine class,
-/// a state function event data type (derived from EventData) and a state machine 
-/// member function pointer.  
+/// a state function event data type (derived from EventData) and a state machine
+/// member function pointer.
 template <class SM, class Data, void (SM::*Func)(const Data*)>
 class EntryAction : public EntryBase
 {
@@ -137,13 +137,13 @@ class ExitBase
 {
 public:
 	/// Called by the state machine engine to execute a state exit action. Called when
-	/// leaving a state. 
-	/// @param[in] sm - A state machine instance. 
+	/// leaving a state.
+	/// @param[in] sm - A state machine instance.
 	virtual void InvokeExitAction(StateMachine* sm) const = 0;
 };
 
 /// @brief ExitAction takes two template arguments: A state machine class and
-/// a state machine member function pointer.   
+/// a state machine member function pointer.
 template <class SM, void (SM::*Func)(void)>
 class ExitAction : public ExitBase
 {
@@ -157,13 +157,13 @@ public:
 	}
 };
 
-/// @brief A structure to hold a single row within the state map. 
+/// @brief A structure to hold a single row within the state map.
 struct StateMapRow
 {
 	const StateBase* const State;
 };
 
-/// @brief A structure to hold a single row within the extended state map. 
+/// @brief A structure to hold a single row within the extended state map.
 struct StateMapRowEx
 {
 	const StateBase* const State;
@@ -172,8 +172,8 @@ struct StateMapRowEx
 	const ExitBase* const Exit;
 };
 
-/// @brief StateMachine implements a software-based state machine. 
-class StateMachine 
+/// @brief StateMachine implements a software-based state machine.
+class StateMachine
 {
 public:
 	enum { EVENT_IGNORED = 0xFE, CANNOT_HAPPEN };
@@ -189,9 +189,9 @@ public:
 	BYTE GetCurrentState() { return m_currentState; }
 
 	/// Gets the maximum number of state machine states.
-	/// @return The maximum state machine states. 
+	/// @return The maximum state machine states.
 	BYTE GetMaxStates() { return MAX_STATES; }
-	
+
 protected:
 	/// External state machine event.
 	/// @param[in] newState - the state machine state to transition to.
@@ -203,7 +203,7 @@ protected:
 	/// @param[in] newState - the state machine state to transition to.
 	/// @param[in] pData - the event data sent to the state.
 	void InternalEvent(BYTE newState, const EventData* pData = NULL);
-	
+
 private:
 	/// The maximum number of state machine states.
 	const BYTE MAX_STATES;
@@ -211,7 +211,7 @@ private:
 	/// The current state machine state.
 	BYTE m_currentState;
 
-	/// The new state the state machine has yet to transition to. 
+	/// The new state the state machine has yet to transition to.
 	BYTE m_newState;
 
 	/// Set to TRUE when an event is generated.
@@ -222,17 +222,17 @@ private:
 
 	/// Gets the state map as defined in the derived class. The BEGIN_STATE_MAP,
 	/// STATE_MAP_ENTRY and END_STATE_MAP macros are used to assist in creating the
-	/// map. A state machine only needs to return a state map using either GetStateMap()  
-	/// or GetStateMapEx() but not both. 
+	/// map. A state machine only needs to return a state map using either GetStateMap()
+	/// or GetStateMapEx() but not both.
 	/// @return An array of StateMapRow pointers with the array size MAX_STATES or
-	/// NULL if the state machine uses the GetStateMapEx(). 
+	/// NULL if the state machine uses the GetStateMapEx().
 	virtual const StateMapRow* GetStateMap() = 0;
 
 	/// Gets the extended state map as defined in the derived class. The BEGIN_STATE_MAP_EX,
-	/// STATE_MAP_ENTRY_EX, STATE_MAP_ENTRY_ALL_EX, and END_STATE_MAP_EX macros are used to 
-	/// assist in creating the map. A state machine only needs to return a state map using 
-	/// either GetStateMap() or GetStateMapEx() but not both. 
-	/// @return An array of StateMapRowEx pointers with the array size MAX_STATES or 
+	/// STATE_MAP_ENTRY_EX, STATE_MAP_ENTRY_ALL_EX, and END_STATE_MAP_EX macros are used to
+	/// assist in creating the map. A state machine only needs to return a state map using
+	/// either GetStateMap() or GetStateMapEx() but not both.
+	/// @return An array of StateMapRowEx pointers with the array size MAX_STATES or
 	/// NULL if the state machine uses the GetStateMap().
 	virtual const StateMapRowEx* GetStateMapEx() = 0;
 
@@ -240,9 +240,9 @@ private:
 	/// @param[in] newState - the new state.
 	void SetCurrentState(BYTE newState) { m_currentState = newState; }
 
-	/// State machine engine that executes the external event and, optionally, all 
+	/// State machine engine that executes the external event and, optionally, all
 	/// internal events generated during state execution.
-	void StateEngine(void); 	
+	void StateEngine(void);
 	void StateEngine(const StateMapRow* const pStateMap);
 	void StateEngine(const StateMapRowEx* const pStateMapEx);
 };
@@ -250,28 +250,28 @@ private:
 #define STATE_DECLARE(stateMachine, stateName, eventData) \
 	void ST_##stateName(const eventData*); \
 	StateAction<stateMachine, eventData, &stateMachine::ST_##stateName> stateName;
-	
+
 #define STATE_DEFINE(stateMachine, stateName, eventData) \
 	void stateMachine::ST_##stateName(const eventData* data)
-		
+
 #define GUARD_DECLARE(stateMachine, guardName, eventData) \
 	BOOL GD_##guardName(const eventData*); \
 	GuardCondition<stateMachine, eventData, &stateMachine::GD_##guardName> guardName;
-	
+
 #define GUARD_DEFINE(stateMachine, guardName, eventData) \
 	BOOL stateMachine::GD_##guardName(const eventData* data)
 
 #define ENTRY_DECLARE(stateMachine, entryName, eventData) \
 	void EN_##entryName(const eventData*); \
 	EntryAction<stateMachine, eventData, &stateMachine::EN_##entryName> entryName;
-	
+
 #define ENTRY_DEFINE(stateMachine, entryName, eventData) \
 	void stateMachine::EN_##entryName(const eventData* data)
 
 #define EXIT_DECLARE(stateMachine, exitName) \
 	void EX_##exitName(void); \
 	ExitAction<stateMachine, &stateMachine::EX_##exitName> exitName;
-	
+
 #define EXIT_DEFINE(stateMachine, exitName) \
 	void stateMachine::EX_##exitName(void)
 
@@ -285,19 +285,19 @@ private:
     };\
 	ASSERT_TRUE(GetCurrentState() < ST_MAX_STATES); \
     ExternalEvent(TRANSITIONS[GetCurrentState()], data); \
-	C_ASSERT((sizeof(TRANSITIONS)/sizeof(BYTE)) == ST_MAX_STATES); 
+	C_ASSERT((sizeof(TRANSITIONS)/sizeof(BYTE)) == ST_MAX_STATES);
 
 #define PARENT_TRANSITION(state) \
 	if (GetCurrentState() >= ST_MAX_STATES && \
 		GetCurrentState() < GetMaxStates()) { \
 		ExternalEvent(state); \
 		return; }
-	
+
 #define BEGIN_STATE_MAP \
 	private:\
 	virtual const StateMapRowEx* GetStateMapEx() { return NULL; }\
 	virtual const StateMapRow* GetStateMap() {\
-		static const StateMapRow STATE_MAP[] = { 
+		static const StateMapRow STATE_MAP[] = {
 
 #define STATE_MAP_ENTRY(stateName)\
 	stateName,
@@ -311,7 +311,7 @@ private:
 	private:\
 	virtual const StateMapRow* GetStateMap() { return NULL; }\
 	virtual const StateMapRowEx* GetStateMapEx() {\
-		static const StateMapRowEx STATE_MAP[] = { 
+		static const StateMapRowEx STATE_MAP[] = {
 
 #define STATE_MAP_ENTRY_EX(stateName)\
 	{ stateName, 0, 0, 0 },

--- a/xallocator.cpp
+++ b/xallocator.cpp
@@ -2,22 +2,23 @@
 #include "Allocator.h"
 #include "Fault.h"
 #include <iostream>
+#include <cstring>	//for memcpy
 
 using namespace std;
 
 #ifndef CHAR_BIT
-#define CHAR_BIT	8 
+#define CHAR_BIT	8
 #endif
 
 #if WIN32
 // @TODO Create a lock for non-Windows platforms when using an operating system
-static CRITICAL_SECTION _criticalSection; 
-#endif 
+static CRITICAL_SECTION _criticalSection;
+#endif
 
 static BOOL _xallocInitialized = FALSE;
 
 // Define STATIC_POOLS to switch from heap blocks mode to static pools mode
-//#define STATIC_POOLS 
+//#define STATIC_POOLS
 #ifdef STATIC_POOLS
 	// Update this section as necessary if you want to use static memory pools.
 	// See also xalloc_init() and xalloc_destroy() for additional updates required.
@@ -35,7 +36,7 @@ static BOOL _xallocInitialized = FALSE;
 	CHAR* _allocator512 [sizeof(AllocatorPool<CHAR[512], MAX_BLOCKS>)];
 	CHAR* _allocator768 [sizeof(AllocatorPool<CHAR[768], MAX_BLOCKS>)];
 	CHAR* _allocator1024 [sizeof(AllocatorPool<CHAR[1024], MAX_BLOCKS>)];
-	CHAR* _allocator2048 [sizeof(AllocatorPool<CHAR[2048], MAX_BLOCKS>)];	
+	CHAR* _allocator2048 [sizeof(AllocatorPool<CHAR[2048], MAX_BLOCKS>)];
 	CHAR* _allocator4096 [sizeof(AllocatorPool<CHAR[4096], MAX_BLOCKS>)];
 
 	// Array of pointers to all allocator instances
@@ -46,23 +47,23 @@ static BOOL _xallocInitialized = FALSE;
 	static Allocator* _allocators[MAX_ALLOCATORS];
 #endif	// STATIC_POOLS
 
-// For C++ applications, must define AUTOMATIC_XALLOCATOR_INIT_DESTROY to 
-// correctly ensure allocators are initialized before any static user C++ 
-// construtor/destructor executes which might call into the xallocator API. 
-// This feature costs 1-byte of RAM per C++ translation unit. This feature 
+// For C++ applications, must define AUTOMATIC_XALLOCATOR_INIT_DESTROY to
+// correctly ensure allocators are initialized before any static user C++
+// construtor/destructor executes which might call into the xallocator API.
+// This feature costs 1-byte of RAM per C++ translation unit. This feature
 // can be disabled only under the following circumstances:
-// 
-// 1) The xallocator is only used within C files. 
-// 2) STATIC_POOLS is undefined and the application never exits main (e.g. 
-// an embedded system). 
 //
-// In either of the two cases above, call xalloc_init() in main at startup, 
+// 1) The xallocator is only used within C files.
+// 2) STATIC_POOLS is undefined and the application never exits main (e.g.
+// an embedded system).
+//
+// In either of the two cases above, call xalloc_init() in main at startup,
 // and xalloc_destroy() before main exits. In all other situations
 // XallocInitDestroy must be used to call xalloc_init() and xalloc_destroy().
 #ifdef AUTOMATIC_XALLOCATOR_INIT_DESTROY
 INT XallocInitDestroy::refCount = 0;
-XallocInitDestroy::XallocInitDestroy() 
-{ 
+XallocInitDestroy::XallocInitDestroy()
+{
 	// Track how many static instances of XallocInitDestroy are created
 	if (refCount++ == 0)
 		xalloc_init();
@@ -76,12 +77,12 @@ XallocInitDestroy::~XallocInitDestroy()
 }
 #endif	// AUTOMATIC_XALLOCATOR_INIT_DESTROY
 
-/// Returns the next higher powers of two. For instance, pass in 12 and 
-/// the value returned would be 16. 
+/// Returns the next higher powers of two. For instance, pass in 12 and
+/// the value returned would be 16.
 /// @param[in] k - numeric value to compute the next higher power of two.
-/// @return	The next higher power of two based on the input k. 
+/// @return	The next higher power of two based on the input k.
 template <class T>
-T nexthigher(T k) 
+T nexthigher(T k)
 {
     k--;
     for (size_t i=1; i<sizeof(T)*CHAR_BIT; i<<=1)
@@ -89,7 +90,7 @@ T nexthigher(T k)
     return k+1;
 }
 
-/// Create the xallocator lock. Call only one time at startup. 
+/// Create the xallocator lock. Call only one time at startup.
 static void lock_init()
 {
 #if WIN32
@@ -108,18 +109,18 @@ static void lock_destroy()
 	_xallocInitialized = FALSE;
 }
 
-/// Lock the shared resource. 
+/// Lock the shared resource.
 static inline void lock_get()
 {
 	if (_xallocInitialized == FALSE)
 		return;
 
 #if WIN32
-	EnterCriticalSection(&_criticalSection); 
+	EnterCriticalSection(&_criticalSection);
 #endif
 }
 
-/// Unlock the shared resource. 
+/// Unlock the shared resource.
 static inline void lock_release()
 {
 	if (_xallocInitialized == FALSE)
@@ -130,11 +131,11 @@ static inline void lock_release()
 #endif
 }
 
-/// Stored a pointer to the allocator instance within the block region. 
+/// Stored a pointer to the allocator instance within the block region.
 ///	a pointer to the client's area within the block.
-/// @param[in] block - a pointer to the raw memory block. 
+/// @param[in] block - a pointer to the raw memory block.
 ///	@param[in] size - the client requested size of the memory block.
-/// @return	A pointer to the client's address within the raw memory block. 
+/// @return	A pointer to the client's address within the raw memory block.
 static inline void *set_block_allocator(void* block, Allocator* allocator)
 {
 	// Cast the raw block memory to a Allocator pointer
@@ -149,7 +150,7 @@ static inline void *set_block_allocator(void* block, Allocator* allocator)
 }
 
 /// Gets the size of the memory block stored within the block.
-/// @param[in] block - a pointer to the client's memory block. 
+/// @param[in] block - a pointer to the client's memory block.
 /// @return	The original allocator instance stored in the memory block.
 static inline Allocator* get_block_allocator(void* block)
 {
@@ -163,9 +164,9 @@ static inline Allocator* get_block_allocator(void* block)
 	return *pAllocatorInBlock;
 }
 
-/// Returns the raw memory block pointer given a client memory pointer. 
-/// @param[in] block - a pointer to the client memory block. 
-/// @return	A pointer to the original raw memory block address. 
+/// Returns the raw memory block pointer given a client memory pointer.
+/// @param[in] block - a pointer to the client memory block.
+/// @return	A pointer to the original raw memory block address.
 static inline void *get_block_ptr(void* block)
 {
 	// Cast the client memory to a Allocator* pointer
@@ -178,18 +179,18 @@ static inline void *get_block_ptr(void* block)
 /// Returns an allocator instance matching the size provided
 /// @param[in] size - allocator block size
 /// @return Allocator instance handling requested block size or NULL
-/// if no allocator exists. 
+/// if no allocator exists.
 static inline Allocator* find_allocator(size_t size)
 {
 	for (INT i=0; i<MAX_ALLOCATORS; i++)
 	{
 		if (_allocators[i] == 0)
 			break;
-		
+
 		if (_allocators[i]->GetBlockSize() == size)
 			return _allocators[i];
 	}
-	
+
 	return NULL;
 }
 
@@ -205,12 +206,12 @@ static inline void insert_allocator(Allocator* allocator)
 			return;
 		}
 	}
-	
+
 	ASSERT();
 }
 
 /// This function must be called exactly one time *before* any other xallocator
-/// API is called. XallocInitDestroy constructor calls this function automatically. 
+/// API is called. XallocInitDestroy constructor calls this function automatically.
 extern "C" void xalloc_init()
 {
 	lock_init();
@@ -232,7 +233,7 @@ extern "C" void xalloc_init()
 	new (&_allocator2048) AllocatorPool<CHAR[2048], MAX_BLOCKS>();
 	new (&_allocator4096) AllocatorPool<CHAR[4096], MAX_BLOCKS>();
 
-	// Populate allocator array with all instances 
+	// Populate allocator array with all instances
 	_allocators[0] = (Allocator*)&_allocator8;
 	_allocators[1] = (Allocator*)&_allocator16;
 	_allocators[2] = (Allocator*)&_allocator32;
@@ -249,7 +250,7 @@ extern "C" void xalloc_init()
 }
 
 /// Called one time when the application exits to cleanup any allocated memory.
-/// ~XallocInitDestroy destructor calls this function automatically. 
+/// ~XallocInitDestroy destructor calls this function automatically.
 extern "C" void xalloc_destroy()
 {
 	lock_get();
@@ -302,7 +303,7 @@ extern "C" Allocator* xallocator_get_allocator(size_t size)
 	ASSERT_TRUE(allocator != NULL);
 #else
 	// If there is not an allocator already created to handle this block size
-	if (allocator == NULL)  
+	if (allocator == NULL)
 	{
 		// Create a new allocator to handle blocks of the size required
 		allocator = new Allocator(blockSize, 0, 0, "xallocator");
@@ -311,7 +312,7 @@ extern "C" Allocator* xallocator_get_allocator(size_t size)
 		insert_allocator(allocator);
 	}
 #endif
-	
+
 	return allocator;
 }
 
@@ -323,7 +324,7 @@ extern "C" void *xmalloc(size_t size)
 {
 	lock_get();
 
-	// Allocate a raw memory block 
+	// Allocate a raw memory block
 	Allocator* allocator = xallocator_get_allocator(size);
 	void* blockMemoryPtr = allocator->Allocate(sizeof(Allocator*) + size);
 
@@ -350,7 +351,7 @@ extern "C" void xfree(void* ptr)
 
 	lock_get();
 
-	// Deallocate the block 
+	// Deallocate the block
 	allocator->Deallocate(blockPtr);
 
 	lock_release();
@@ -364,16 +365,16 @@ extern "C" void *xrealloc(void *oldMem, size_t size)
 	if (oldMem == 0)
 		return xmalloc(size);
 
-	if (size == 0) 
+	if (size == 0)
 	{
 		xfree(oldMem);
 		return 0;
 	}
-	else 
+	else
 	{
 		// Create a new memory block
 		void* newMem = xmalloc(size);
-		if (newMem != 0) 
+		if (newMem != 0)
 		{
 			// Get the original allocator instance from the old memory block
 			Allocator* oldAllocator = get_block_allocator(oldMem);


### PR DESCRIPTION
InternalEvent could always use the heap, even when called from ExternalEvent
actions with NoEventData.
This update has InternalEvent also respect the no heap rule

Co-authored-by: Min-Ching Ho <minching.ho@span.io>